### PR TITLE
Add Offline CheatSheet

### DIFF
--- a/scripts/config.yml
+++ b/scripts/config.yml
@@ -10,6 +10,8 @@ user_agent_val : Generator-for-Offline-Documentation (https://github.com/abshk-j
 
 url_print : [https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Print_version,https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/The_OpenSCAD_Language]
 
+cheatsheet_url : https://openscad.org/cheatsheet/
+
 options :
   enable-local-file-access: null
   --keep-relative-links: ''


### PR DESCRIPTION
This Pull Request adds the functionality to download the CheatSheet from [OpenSCAD CheatSheet](https://openscad.org/cheatsheet/).

The function `cheatSheet()` enables us with the same, and calls the functions `getCSS()` to download the CSS files, and also calls the function `getTags()` to change the WikiBooks links in the page to redirect them to the User Manual downloaded earlier.